### PR TITLE
Potential fix for code scanning alert no. 10: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -1,4 +1,6 @@
 name: Node.js CI
+permissions:
+  contents: read
 
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/pSecurIT/ShotSpot/security/code-scanning/10](https://github.com/pSecurIT/ShotSpot/security/code-scanning/10)

To fix the problem, add a `permissions` key to the workflow file. The safest and most explicit approach is to set this at the root level (i.e., just after `name:` and before `on:`) so that all jobs in the workflow inherit these permissions by default. If some jobs require more than `contents: read`, those jobs can override the root value. However, in this workflow all jobs (backend, frontend, security) appear to only install dependencies, run builds/lints/tests, and do not upload artifacts, create releases, or comment on issues/PRs—so setting `permissions: contents: read` at the root level is both safe and sufficient.

Modify `.github/workflows/node.js.yml` to add these lines:

```yaml
name: Node.js CI
permissions:
  contents: read
```

Place this immediately after the `name:` line (line 1), shifting all subsequent lines downward.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
